### PR TITLE
Fix: Send email to updated Looker User

### DIFF
--- a/looker/resource_looker_user.go
+++ b/looker/resource_looker_user.go
@@ -122,6 +122,11 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, c interface
 		if updateCredsErr != nil {
 			return diag.FromErr(updateCredsErr)
 		}
+
+		_, sendEmailErr := api.SendUserCredentialsEmailPasswordReset(d.Id(), "", nil)
+		if sendEmailErr != nil {
+			return diag.FromErr(sendEmailErr)
+		}
 	}
 
 	return resourceUserRead(ctx, d, c)


### PR DESCRIPTION
## Description

When a user email is updated, a welcome email isn't sent to the new email address, meaning they can't log in! This is a fix for this bug. 

## Has this been tested? 

Yes! It has been tested against a real life problem we had provisioning a user. 

