### PR TITLE
Feature: Run acceptance tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,71 @@
+name: Tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - ".github/workflows/test.yaml"
+      - "**.go"
+
+concurrency:
+  group: tests
+  cancel-in-progress: false
+
+env:
+  go-version: "1.19"
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.go-version }}
+
+      - name: Check out the code
+        uses: actions/checkout@v3
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.49
+          args: -c ${{ github.workspace }}/.golangci.yaml
+
+  unit:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.go-version }}
+
+      - name: Check out the code
+        uses: actions/checkout@v3
+
+      - name: Run tests
+        run: make test
+
+  acceptance:
+    name: Acceptance Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.go-version }}
+
+      - name: Check out the code
+        uses: actions/checkout@v3
+
+      - name: Run tests
+        run: make testacc
+        env:
+          LOOKERSDK_BASE_URL: ${{ secrets.LOOKERSDK_BASE_URL }}
+          LOOKERSDK_CLIENT_ID: ${{ secrets.LOOKERSDK_CLIENT_ID }}
+          LOOKERSDK_CLIENT_SECRET: ${{ secrets.LOOKERSDK_CLIENT_SECRET }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Build directory
+out/

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,2 @@
+run:
+  timeout: 5m

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+HOSTNAME = terraform.example.com
+NAMESPACE = local
+NAME = looker
+
+BINARY = terraform-provider-${NAME}
+VERSION ?= 0.0.1
+BUILD_DIR ?= $(CURDIR)/out
+
+GO_PACKAGES := $(shell go list ./... | grep -v vendor) 
+GO_FILES := $(shell find . -name '*.go' | grep -v vendor)
+GO_OS ?= $(shell go env GOOS)
+GO_ARCH ?= $(shell go env GOARCH)
+
+.PHONY: build
+build:
+	@go build -v -o ${BUILD_DIR}/${BINARY}_v${VERSION}
+
+.PHONY: install
+install: build
+	@mkdir -p ${HOME}/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/$(VERSION)/${GO_OS}_${GO_ARCH}
+	@cp ${BUILD_DIR}/${BINARY}_v${VERSION} ${HOME}/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/$(VERSION)/${GO_OS}_${GO_ARCH}
+
+.PHONY: gen
+gen:
+	@go generate ./...
+
+.PHONY: clean
+clean: 
+	@rm -rf ${BUILD_DIR} ${HOME}/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}
+
+.PHONY: lint
+lint:
+	@golangci-lint run -c .golangci.yaml
+
+.PHONY: test
+test: 
+	@go test ${GO_PACKAGES} || exit 1                                                   
+	@echo ${GO_PACKAGES} | xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4                    
+
+.PHONY: testacc
+testacc:
+	@TF_ACC=1 go test ${GO_PACKAGES} -v $(TESTARGS) -timeout 120m
+
+.PHONY: sweep
+sweep:
+	@echo "WARNING: This will destroy infrastructure. Only use on development instances."
+	@go test ./looker -v -sweep="phony" $(SWEEPARGS) -timeout 60m

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/resolutionlife/terraform-provider-looker
 go 1.18
 
 require (
+	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.17.0
@@ -18,6 +19,7 @@ require (
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
@@ -25,7 +27,6 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 // indirect
 	github.com/hashicorp/go-hclog v1.2.0 // indirect
 	github.com/hashicorp/go-plugin v1.4.4 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect

--- a/looker/provider_test.go
+++ b/looker/provider_test.go
@@ -1,0 +1,36 @@
+package looker
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/looker-open-source/sdk-codegen/go/rtl"
+	client "github.com/looker-open-source/sdk-codegen/go/sdk/v4"
+)
+
+var (
+	testAccProviders map[string]func() (*schema.Provider, error)
+	testAccProvider  *schema.Provider
+)
+
+func init() {
+	testAccProvider = NewProvider()
+	testAccProviders = map[string]func() (*schema.Provider, error){
+		"looker": func() (*schema.Provider, error) { return testAccProvider, nil },
+	}
+}
+
+func newTestLookerSDK() (*client.LookerSDK, error) {
+	apiSettings, err := rtl.NewSettingsFromEnv()
+	if err != nil {
+		return nil, fmt.Errorf("unable to create Looker client settings from environment variables: %w", err)
+	}
+	return client.NewLookerSDK(rtl.NewAuthSession(apiSettings)), nil
+}
+
+// TestMain is used to parse special test flags to invoke sweepers.
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}

--- a/looker/resource_looker_user_test.go
+++ b/looker/resource_looker_user_test.go
@@ -1,0 +1,72 @@
+package looker
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	v4 "github.com/looker-open-source/sdk-codegen/go/sdk/v4"
+	"github.com/resolutionlife/terraform-provider-looker/internal/conv"
+)
+
+func init() {
+	// Add a sweeper to remove users that have emails starting with `test-acc`.
+	resource.AddTestSweepers("looker_user", &resource.Sweeper{
+		Name: "looker_user",
+		F: func(_ string) error {
+			c, err := newTestLookerSDK()
+			if err != nil {
+				return err
+			}
+
+			users, err := c.SearchUsers(v4.RequestSearchUsers{
+				Email: conv.PString("test-acc%"),
+			}, nil)
+			if err != nil {
+				return err
+			}
+
+			for _, u := range users {
+				if _, err := c.DeleteUser(*u.Id, nil); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		},
+	})
+}
+
+func TestAccLookerUser(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				  resource "looker_user" "test_acc" {
+				    email      = "test-acc@resolutionlife.com"
+				    first_name = "John"
+				    last_name  = "Doe"
+				  }
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("looker_user.test_acc", "email", "test-acc@resolutionlife.com"),
+					resource.TestCheckResourceAttr("looker_user.test_acc", "first_name", "John"),
+					resource.TestCheckResourceAttr("looker_user.test_acc", "last_name", "Doe"),
+				),
+			},
+			{
+				Config: `
+				  resource "looker_user" "test_acc" {
+				    email      = "test-acc@resolutionlife.com"
+				    first_name = "Jane"
+				    last_name  = "Smith"
+				  }
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("looker_user.test_acc", "first_name", "Jane"),
+					resource.TestCheckResourceAttr("looker_user.test_acc", "last_name", "Smith"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
# Description

This automates running Terraform acceptance tests on PRs and pushes to the `main` branch. There is a simple example case for the user resource that checks it creates and updates nicely.

Tests run on our sandbox Looker instance with a provider configured by environments variables in the repository secrets.

# Anything else?

Added a Makefile to help development.