### PR TITLE
Fix: SAML groups with role IDs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.17.0
 	github.com/looker-open-source/sdk-codegen/go v0.0.2
 	github.com/pkg/errors v0.9.1
-	github.com/stretchr/testify v1.7.0
 )
 
 require (
@@ -56,7 +55,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/oklog/run v1.0.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/russross/blackfriday v1.6.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
@@ -76,5 +74,4 @@ require (
 	google.golang.org/grpc v1.46.0 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/ini.v1 v1.61.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0 // indirect
 )

--- a/looker/resource_looker_group_group_test.go
+++ b/looker/resource_looker_group_group_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	client "github.com/looker-open-source/sdk-codegen/go/sdk/v4"
 	sdk "github.com/looker-open-source/sdk-codegen/go/sdk/v4"
 	"github.com/pkg/errors"
 	"github.com/resolutionlife/terraform-provider-looker/internal/conv"
@@ -87,7 +86,7 @@ func testAccGroupGroupBinding(parentGroupResource, childGroupResource string) re
 			return errors.New("child group ID is not set")
 		}
 
-		client := testAccProvider.Meta().(*client.LookerSDK)
+		client := testAccProvider.Meta().(*sdk.LookerSDK)
 
 		parentSubGroups, err := client.AllGroupGroups(parentRes.Primary.ID, "", nil)
 		if err != nil {


### PR DESCRIPTION
Fix to correctly set "groups with role IDs" on the Looker SAML config