### PR TITLE
Test: Resource looker_role_groups

### DIFF
--- a/looker/resource_looker_role_groups_test.go
+++ b/looker/resource_looker_role_groups_test.go
@@ -1,0 +1,152 @@
+package looker
+
+import (
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	sdk "github.com/looker-open-source/sdk-codegen/go/sdk/v4"
+	"github.com/pkg/errors"
+	"github.com/resolutionlife/terraform-provider-looker/internal/conv"
+)
+
+func init() {
+	// Add a sweeper to remove roles, groups and role groups that have names starting with `test-acc`.
+	// TODO: Maybe move these sweepers to a dedicated test utils package for re-usability
+	resource.AddTestSweepers("looker_role_groups", &resource.Sweeper{
+		Name: "looker_role_groups",
+		F: func(_ string) error {
+			c, err := newTestLookerSDK()
+			if err != nil {
+				return err
+			}
+
+			permissionSets, err := c.SearchPermissionSets(sdk.RequestSearchModelSets{
+				Name: conv.PString("test-acc%"),
+			}, nil)
+			if err != nil {
+				return err
+			}
+
+			for _, permissionSet := range permissionSets {
+				if _, err := c.DeletePermissionSet(*permissionSet.Id, nil); err != nil {
+					return err
+				}
+			}
+
+			modelSets, err := c.SearchModelSets(sdk.RequestSearchModelSets{
+				Name: conv.PString("test-acc%"),
+			}, nil)
+			if err != nil {
+				return err
+			}
+
+			for _, modelSet := range modelSets {
+				if _, err := c.DeleteModelSet(*modelSet.Id, nil); err != nil {
+					return err
+				}
+			}
+
+			groups, err := c.SearchGroups(sdk.RequestSearchGroups{
+				Name: conv.PString("test-acc%"),
+			}, nil)
+			if err != nil {
+				return err
+			}
+
+			for _, g := range groups {
+				if _, err := c.DeleteGroup(*g.Id, nil); err != nil {
+					return err
+				}
+			}
+
+			roles, err := c.SearchRoles(sdk.RequestSearchRoles{
+				Name: conv.PString("test-acc%"),
+			}, nil)
+			if err != nil {
+				return err
+			}
+
+			for _, role := range roles {
+				if _, err := c.DeleteRole(*role.Id, nil); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		},
+	})
+}
+
+func TestAccLookerRoleGroups(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				resource "looker_permission_set" "test_acc" {
+					name        = "test-acc-permission-set"
+					permissions = ["access_data", "see_lookml", "see_lookml_dashboards"]
+				}
+
+				resource "looker_model_set" "test_acc" {
+					name   = "test-acc-model-set"
+					models = ["test_dataset_1", "test_dataset_2", "test_both_datasets"]
+				}
+
+				resource "looker_role" "test_acc" {
+					name              = "test-acc-role"
+					model_set_id      = looker_model_set.test_acc.id
+					permission_set_id = looker_permission_set.test_acc.id
+				}
+
+				resource "looker_group" "test_acc_1" {
+					name = "test-acc-group-1"
+				}
+
+				resource "looker_group" "test_acc_2" {
+					name = "test-acc-group-2"
+				}
+
+				resource "looker_role_groups" "test_acc" {
+					role_id   = looker_role.test_acc.id
+					group_ids = [looker_group.test_acc_1.id, looker_group.test_acc_2.id]
+				} 
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("looker_role_groups.test_acc", "group_ids.#", "2"),
+					testAccRoleGroups("looker_role_groups.test_acc"),
+				),
+			},
+		},
+	})
+}
+
+func testAccRoleGroups(roleGroupResource string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		roleGroupsRes, ok := s.RootModule().Resources[roleGroupResource]
+		if !ok {
+			return errors.Errorf("Not found: %s", roleGroupResource)
+		}
+		if roleGroupsRes.Primary.ID == "" {
+			return errors.New("role groups ID is not set")
+		}
+
+		client := testAccProvider.Meta().(*sdk.LookerSDK)
+
+		roleGroups, err := client.RoleGroups(roleGroupsRes.Primary.ID, "", nil)
+		if err != nil {
+			return errors.Wrapf(err, "failed to retrieve role group with id: %v", roleGroupsRes.Primary.ID)
+		}
+
+		var groupIds []string
+		for _, roleGroup := range roleGroups {
+			groupIds = append(groupIds, *roleGroup.ExternalGroupId)
+		}
+
+		spew.Dump(groupIds)
+
+		return nil
+	}
+}

--- a/looker/resource_looker_role_groups_test.go
+++ b/looker/resource_looker_role_groups_test.go
@@ -24,8 +24,21 @@ func init() {
 				return err
 			}
 
+			roles, err := c.SearchRoles(sdk.RequestSearchRoles{
+				Name: conv.P("test-acc%"),
+			}, nil)
+			if err != nil {
+				return err
+			}
+
+			for _, role := range roles {
+				if _, err := c.DeleteRole(*role.Id, nil); err != nil {
+					return err
+				}
+			}
+
 			permissionSets, err := c.SearchPermissionSets(sdk.RequestSearchModelSets{
-				Name: conv.PString("test-acc%"),
+				Name: conv.P("test-acc%"),
 			}, nil)
 			if err != nil {
 				return err
@@ -38,7 +51,7 @@ func init() {
 			}
 
 			modelSets, err := c.SearchModelSets(sdk.RequestSearchModelSets{
-				Name: conv.PString("test-acc%"),
+				Name: conv.P("test-acc%"),
 			}, nil)
 			if err != nil {
 				return err
@@ -51,7 +64,7 @@ func init() {
 			}
 
 			groups, err := c.SearchGroups(sdk.RequestSearchGroups{
-				Name: conv.PString("test-acc%"),
+				Name: conv.P("test-acc%"),
 			}, nil)
 			if err != nil {
 				return err
@@ -59,19 +72,6 @@ func init() {
 
 			for _, g := range groups {
 				if _, err := c.DeleteGroup(*g.Id, nil); err != nil {
-					return err
-				}
-			}
-
-			roles, err := c.SearchRoles(sdk.RequestSearchRoles{
-				Name: conv.PString("test-acc%"),
-			}, nil)
-			if err != nil {
-				return err
-			}
-
-			for _, role := range roles {
-				if _, err := c.DeleteRole(*role.Id, nil); err != nil {
 					return err
 				}
 			}

--- a/looker/resource_looker_role_groups_test.go
+++ b/looker/resource_looker_role_groups_test.go
@@ -1,14 +1,16 @@
 package looker
 
 import (
+	"strings"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	sdk "github.com/looker-open-source/sdk-codegen/go/sdk/v4"
 	"github.com/pkg/errors"
 	"github.com/resolutionlife/terraform-provider-looker/internal/conv"
+	"github.com/resolutionlife/terraform-provider-looker/internal/slice"
 )
 
 func init() {
@@ -116,14 +118,46 @@ func TestAccLookerRoleGroups(t *testing.T) {
 				`,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("looker_role_groups.test_acc", "group_ids.#", "2"),
-					testAccRoleGroups("looker_role_groups.test_acc"),
+					testAccRoleGroups("looker_role_groups.test_acc", []string{"looker_group.test_acc_1", "looker_group.test_acc_2"}),
+				),
+			},
+			{
+				Config: `
+				resource "looker_permission_set" "test_acc" {
+					name        = "test-acc-permission-set"
+					permissions = ["access_data", "see_lookml", "see_lookml_dashboards"]
+				}
+
+				resource "looker_model_set" "test_acc" {
+					name   = "test-acc-model-set"
+					models = ["test_dataset_1", "test_dataset_2", "test_both_datasets"]
+				}
+
+				resource "looker_role" "test_acc" {
+					name              = "test-acc-role"
+					model_set_id      = looker_model_set.test_acc.id
+					permission_set_id = looker_permission_set.test_acc.id
+				}
+
+				resource "looker_group" "test_acc_1" {
+					name = "test-acc-group-1"
+				}
+
+				resource "looker_role_groups" "test_acc" {
+					role_id   = looker_role.test_acc.id
+					group_ids = [looker_group.test_acc_1.id]
+				} 
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("looker_role_groups.test_acc", "group_ids.#", "1"),
+					testAccRoleGroups("looker_role_groups.test_acc", []string{"looker_group.test_acc_1"}),
 				),
 			},
 		},
 	})
 }
 
-func testAccRoleGroups(roleGroupResource string) resource.TestCheckFunc {
+func testAccRoleGroups(roleGroupResource string, groupResources []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		roleGroupsRes, ok := s.RootModule().Resources[roleGroupResource]
 		if !ok {
@@ -133,19 +167,40 @@ func testAccRoleGroups(roleGroupResource string) resource.TestCheckFunc {
 			return errors.New("role groups ID is not set")
 		}
 
+		expectedGroupIds := []string{}
+		for _, groupResource := range groupResources {
+			groupRes, ok := s.RootModule().Resources[groupResource]
+			if !ok {
+				return errors.Errorf("Not found: %s", groupResource)
+			}
+			if groupRes.Primary.ID == "" {
+				return errors.New("group ID is not set")
+			}
+
+			expectedGroupIds = append(expectedGroupIds, groupRes.Primary.ID)
+		}
+
 		client := testAccProvider.Meta().(*sdk.LookerSDK)
 
-		roleGroups, err := client.RoleGroups(roleGroupsRes.Primary.ID, "", nil)
+		// role group binding resource id is NOT the id of the role resource
+		roleId := strings.Split(roleGroupsRes.Primary.ID, "_")
+		if len(roleId) < 2 {
+			diag.Errorf("invalid id, should be of the form <role_id>_<group_ids>")
+		}
+
+		roleGroups, err := client.RoleGroups(roleId[0], "", nil)
 		if err != nil {
 			return errors.Wrapf(err, "failed to retrieve role group with id: %v", roleGroupsRes.Primary.ID)
 		}
 
-		var groupIds []string
+		groupIds := []string{}
 		for _, roleGroup := range roleGroups {
-			groupIds = append(groupIds, *roleGroup.ExternalGroupId)
+			groupIds = append(groupIds, *roleGroup.Id)
 		}
 
-		spew.Dump(groupIds)
+		if !slice.UnorderedEqual(groupIds, expectedGroupIds) {
+			return errors.Errorf("groups in role do not match expected: %v actual: %v", expectedGroupIds, groupIds)
+		}
 
 		return nil
 	}

--- a/looker/resource_looker_role_test.go
+++ b/looker/resource_looker_role_test.go
@@ -103,7 +103,7 @@ func testAccRole(roleResource string, expectedModelsSets, expectedPermSets []str
 			return errors.Errorf("Not found: %s", roleResource)
 		}
 		if roleRes.Primary.ID == "" {
-			return errors.New("role set ID is not set")
+			return errors.New("role ID is not set")
 		}
 
 		client := testAccProvider.Meta().(*sdk.LookerSDK)

--- a/looker/resource_looker_role_test.go
+++ b/looker/resource_looker_role_test.go
@@ -92,6 +92,29 @@ func TestAccLookerRole(t *testing.T) {
 					testAccRole("looker_role.test_acc", []string{"test_dataset_1", "test_dataset_2", "test_both_datasets"}, []string{"access_data", "see_lookml", "see_lookml_dashboards"}),
 				),
 			},
+			{
+				Config: `
+				resource "looker_permission_set" "test_acc" {
+					name        = "test-acc-permission-set"
+					permissions = ["see_lookml", "see_lookml_dashboards"]
+				}
+
+				resource "looker_model_set" "test_acc" {
+					name   = "test-acc-model-set"
+					models = ["test_dataset_1", "test_both_datasets"]
+				}
+
+				resource "looker_role" "test_acc" {
+					name              = "test-acc-role"
+					model_set_id      = looker_model_set.test_acc.id
+					permission_set_id = looker_permission_set.test_acc.id
+				}
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("looker_role.test_acc", "name", "test-acc-role"),
+					testAccRole("looker_role.test_acc", []string{"test_dataset_1", "test_both_datasets"}, []string{"see_lookml", "see_lookml_dashboards"}),
+				),
+			},
 		},
 	})
 }

--- a/looker/resource_looker_role_test.go
+++ b/looker/resource_looker_role_test.go
@@ -1,0 +1,126 @@
+package looker
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	sdk "github.com/looker-open-source/sdk-codegen/go/sdk/v4"
+	"github.com/pkg/errors"
+	"github.com/resolutionlife/terraform-provider-looker/internal/conv"
+	"github.com/resolutionlife/terraform-provider-looker/internal/slice"
+)
+
+func init() {
+	// Add a sweeper to remove model sets, permission sets and roles that have names starting with `test-acc`.
+	resource.AddTestSweepers("looker_roles", &resource.Sweeper{
+		Name: "looker_roles",
+		F: func(_ string) error {
+			c, err := newTestLookerSDK()
+			if err != nil {
+				return err
+			}
+
+			permissionSets, err := c.SearchPermissionSets(sdk.RequestSearchModelSets{
+				Name: conv.PString("test-acc%"),
+			}, nil)
+			if err != nil {
+				return err
+			}
+
+			for _, permissionSet := range permissionSets {
+				if _, err := c.DeletePermissionSet(*permissionSet.Id, nil); err != nil {
+					return err
+				}
+			}
+
+			modelSets, err := c.SearchModelSets(sdk.RequestSearchModelSets{
+				Name: conv.PString("test-acc%"),
+			}, nil)
+			if err != nil {
+				return err
+			}
+
+			for _, modelSet := range modelSets {
+				if _, err := c.DeleteModelSet(*modelSet.Id, nil); err != nil {
+					return err
+				}
+			}
+
+			roles, err := c.SearchRoles(sdk.RequestSearchRoles{
+				Name: conv.PString("test-acc%"),
+			}, nil)
+			if err != nil {
+				return err
+			}
+
+			for _, role := range roles {
+				if _, err := c.DeleteRole(*role.Id, nil); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		},
+	})
+}
+
+func TestAccLookerRole(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				resource "looker_permission_set" "test_acc" {
+					name        = "test-acc-permission-set"
+					permissions = ["access_data", "see_lookml", "see_lookml_dashboards"]
+				}
+
+				resource "looker_model_set" "test_acc" {
+					name   = "test-acc-model-set"
+					models = ["test_dataset_1", "test_dataset_2", "test_both_datasets"]
+				}
+
+				resource "looker_role" "test_acc" {
+					name              = "test-acc-role"
+					model_set_id      = looker_model_set.test_acc.id
+					permission_set_id = looker_permission_set.test_acc.id
+				}
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("looker_role.test_acc", "name", "test-acc-role"),
+					testAccRole("looker_role.test_acc", []string{"test_dataset_1", "test_dataset_2", "test_both_datasets"}, []string{"access_data", "see_lookml", "see_lookml_dashboards"}),
+				),
+			},
+		},
+	})
+}
+
+func testAccRole(roleResource string, expectedModelsSets, expectedPermSets []string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		roleRes, ok := s.RootModule().Resources[roleResource]
+		if !ok {
+			return errors.Errorf("Not found: %s", roleResource)
+		}
+		if roleRes.Primary.ID == "" {
+			return errors.New("role set ID is not set")
+		}
+
+		client := testAccProvider.Meta().(*sdk.LookerSDK)
+
+		role, err := client.Role(roleRes.Primary.ID, nil)
+		if err != nil {
+			return errors.Wrapf(err, "failed to retrieve role with id: %v", roleRes.Primary.ID)
+		}
+
+		if !slice.UnorderedEqual(*role.PermissionSet.Permissions, expectedPermSets) {
+			return errors.Errorf("permissions in role do not match expected permissions: %v actual: %v", expectedPermSets, *role.PermissionSet.Permissions)
+		}
+
+		if !slice.UnorderedEqual(*role.ModelSet.Models, expectedModelsSets) {
+			return errors.Errorf("models in role do not match expected models: %v actual: %v", expectedModelsSets, *role.ModelSet.Models)
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
# Description

Adds tests for the `looker_role_groups` binding resource, including checking against the API. This one is slightly different in how the ID's work since the role ID is not the same as the `looker_role_groups` resource, luckly @jessicasomaiya has included the role ID as part of the resource ID making testing this much easier.