### PR TITLE
Chore: Replace github.com/pkg/errors with Go errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,6 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.4.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.17.0
 	github.com/looker-open-source/sdk-codegen/go v0.0.2
-	github.com/pkg/errors v0.9.1
-	github.com/stretchr/testify v1.7.0
 )
 
 require (
@@ -56,7 +54,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/oklog/run v1.0.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/russross/blackfriday v1.6.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
@@ -77,7 +74,6 @@ require (
 	google.golang.org/grpc v1.46.0 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/ini.v1 v1.61.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0 // indirect
 )
 
 replace github.com/looker-open-source/sdk-codegen/go => github.com/resolutionlife/looker-sdk-codegen/go v0.0.0-20220923092236-8ec73633c5e0

--- a/go.sum
+++ b/go.sum
@@ -291,7 +291,6 @@ github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/looker/resource_looker_group_group_test.go
+++ b/looker/resource_looker_group_group_test.go
@@ -1,12 +1,14 @@
 package looker
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	sdk "github.com/looker-open-source/sdk-codegen/go/sdk/v4"
-	"github.com/pkg/errors"
+
 	"github.com/resolutionlife/terraform-provider-looker/internal/conv"
 	"github.com/resolutionlife/terraform-provider-looker/internal/slice"
 )
@@ -72,7 +74,7 @@ func testAccGroupGroupBinding(parentGroupResource, childGroupResource string) re
 	return func(s *terraform.State) error {
 		parentRes, ok := s.RootModule().Resources[parentGroupResource]
 		if !ok {
-			return errors.Errorf("Not found: %s", parentGroupResource)
+			return fmt.Errorf("Not found: %s", parentGroupResource)
 		}
 		if parentRes.Primary.ID == "" {
 			return errors.New("parent group ID is not set")
@@ -80,7 +82,7 @@ func testAccGroupGroupBinding(parentGroupResource, childGroupResource string) re
 
 		childRes, ok := s.RootModule().Resources[childGroupResource]
 		if !ok {
-			return errors.Errorf("Not found: %s", childGroupResource)
+			return fmt.Errorf("Not found: %s", childGroupResource)
 		}
 		if childRes.Primary.ID == "" {
 			return errors.New("child group ID is not set")
@@ -90,7 +92,7 @@ func testAccGroupGroupBinding(parentGroupResource, childGroupResource string) re
 
 		parentSubGroups, err := client.AllGroupGroups(parentRes.Primary.ID, "", nil)
 		if err != nil {
-			return errors.Wrapf(err, "failed to retrieve parent group with id: %v", parentRes.Primary.ID)
+			return fmt.Errorf("failed to retrieve parent group with id: %w", err)
 		}
 
 		groupIds := []string{}
@@ -99,7 +101,7 @@ func testAccGroupGroupBinding(parentGroupResource, childGroupResource string) re
 		}
 
 		if !slice.Contains(groupIds, childRes.Primary.ID) {
-			return errors.Errorf("parent group contains groups with ID %v does not contain group with ID %v", groupIds, childRes.Primary.ID)
+			return fmt.Errorf("parent group contains groups with ID %v does not contain group with ID %v", groupIds, childRes.Primary.ID)
 		}
 
 		return nil

--- a/looker/resource_looker_group_user.go
+++ b/looker/resource_looker_group_user.go
@@ -2,6 +2,7 @@ package looker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -10,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	sdk "github.com/looker-open-source/sdk-codegen/go/sdk/v4"
-	"github.com/pkg/errors"
+
 	"github.com/resolutionlife/terraform-provider-looker/internal/conv"
 	"github.com/resolutionlife/terraform-provider-looker/internal/slice"
 )

--- a/looker/resource_looker_group_user_test.go
+++ b/looker/resource_looker_group_user_test.go
@@ -1,9 +1,9 @@
 package looker
 
 import (
+	"errors"
+	"fmt"
 	"testing"
-
-	"github.com/pkg/errors"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -93,7 +93,7 @@ func testAccGroupUserBinding(userResource, groupResource string) resource.TestCh
 	return func(s *terraform.State) error {
 		userRes, ok := s.RootModule().Resources[userResource]
 		if !ok {
-			return errors.Errorf("Not found: %s", userResource)
+			return fmt.Errorf("Not found: %s", userResource)
 		}
 		if userRes.Primary.ID == "" {
 			return errors.New("user ID is not set")
@@ -101,7 +101,7 @@ func testAccGroupUserBinding(userResource, groupResource string) resource.TestCh
 
 		groupRes, ok := s.RootModule().Resources[groupResource]
 		if !ok {
-			return errors.Errorf("Not found: %s", groupResource)
+			return fmt.Errorf("Not found: %s", groupResource)
 		}
 		if groupRes.Primary.ID == "" {
 			return errors.New("group ID is not set")
@@ -111,16 +111,16 @@ func testAccGroupUserBinding(userResource, groupResource string) resource.TestCh
 
 		user, err := client.User(userRes.Primary.ID, "", nil)
 		if err != nil {
-			return errors.Wrapf(err, "failed to retrieve user with id: %v", userRes.Primary.ID)
+			return fmt.Errorf("failed to retrieve user with id %v: %w", userRes.Primary.ID, err)
 		}
 
 		group, err := client.Group(groupRes.Primary.ID, "", nil)
 		if err != nil {
-			return errors.Wrapf(err, "failed to retrieve group with id: %v", userRes.Primary.ID)
+			return fmt.Errorf("failed to retrieve group with id %v: %w", userRes.Primary.ID, err)
 		}
 
 		if !slice.Contains(*user.GroupIds, *group.Id) {
-			return errors.Errorf("group with ID %v does not contain user %v", *group.Id, *user.Id)
+			return fmt.Errorf("group with ID %v does not contain user %v", *group.Id, *user.Id)
 		}
 
 		return nil

--- a/looker/resource_looker_model_set_test.go
+++ b/looker/resource_looker_model_set_test.go
@@ -1,12 +1,14 @@
 package looker
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	sdk "github.com/looker-open-source/sdk-codegen/go/sdk/v4"
-	"github.com/pkg/errors"
+
 	"github.com/resolutionlife/terraform-provider-looker/internal/conv"
 	"github.com/resolutionlife/terraform-provider-looker/internal/slice"
 )
@@ -77,7 +79,7 @@ func testAccModelSet(modelSetResource string, expectedModelsSets []string) resou
 	return func(s *terraform.State) error {
 		modelSetRes, ok := s.RootModule().Resources[modelSetResource]
 		if !ok {
-			return errors.Errorf("Not found: %s", modelSetResource)
+			return fmt.Errorf("Not found: %s", modelSetResource)
 		}
 		if modelSetRes.Primary.ID == "" {
 			return errors.New("model set ID is not set")
@@ -87,11 +89,11 @@ func testAccModelSet(modelSetResource string, expectedModelsSets []string) resou
 
 		modelSet, err := client.ModelSet(modelSetRes.Primary.ID, "", nil)
 		if err != nil {
-			return errors.Wrapf(err, "failed to retrieve model set with id: %v", modelSetRes.Primary.ID)
+			return fmt.Errorf("failed to retrieve model set with id %v: %w", modelSetRes.Primary.ID, err)
 		}
 
 		if !slice.UnorderedEqual(*modelSet.Models, expectedModelsSets) {
-			return errors.Errorf("models in model set do not match expected: %v actual: %v", expectedModelsSets, *modelSet.Models)
+			return fmt.Errorf("models in model set do not match expected: %v actual: %v", expectedModelsSets, *modelSet.Models)
 		}
 
 		return nil

--- a/looker/resource_looker_permission_set_test.go
+++ b/looker/resource_looker_permission_set_test.go
@@ -1,12 +1,14 @@
 package looker
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	sdk "github.com/looker-open-source/sdk-codegen/go/sdk/v4"
-	"github.com/pkg/errors"
+
 	"github.com/resolutionlife/terraform-provider-looker/internal/conv"
 	"github.com/resolutionlife/terraform-provider-looker/internal/slice"
 )
@@ -77,7 +79,7 @@ func testAccPermissionSet(permSetResource string, expectedPermSets []string) res
 	return func(s *terraform.State) error {
 		permSetRes, ok := s.RootModule().Resources[permSetResource]
 		if !ok {
-			return errors.Errorf("Not found: %s", permSetResource)
+			return fmt.Errorf("Not found: %s", permSetResource)
 		}
 		if permSetRes.Primary.ID == "" {
 			return errors.New("permission set ID is not set")
@@ -87,11 +89,11 @@ func testAccPermissionSet(permSetResource string, expectedPermSets []string) res
 
 		permSet, err := client.PermissionSet(permSetRes.Primary.ID, "", nil)
 		if err != nil {
-			return errors.Wrapf(err, "failed to retrieve permission set with id: %v", permSetRes.Primary.ID)
+			return fmt.Errorf("failed to retrieve permission set with id %v: %w", permSetRes.Primary.ID, err)
 		}
 
 		if !slice.UnorderedEqual(*permSet.Permissions, expectedPermSets) {
-			return errors.Errorf("permissions in permission set do not match expected: %v actual: %v", expectedPermSets, *permSet.Permissions)
+			return fmt.Errorf("permissions in permission set do not match expected: %v actual: %v", expectedPermSets, *permSet.Permissions)
 		}
 
 		return nil

--- a/looker/resource_looker_role_groups.go
+++ b/looker/resource_looker_role_groups.go
@@ -2,6 +2,7 @@ package looker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -9,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	sdk "github.com/looker-open-source/sdk-codegen/go/sdk/v4"
-	"github.com/pkg/errors"
+
 	"github.com/resolutionlife/terraform-provider-looker/internal/conv"
 	"github.com/resolutionlife/terraform-provider-looker/internal/slice"
 )
@@ -208,7 +209,7 @@ func getGroupsOnRole(api *sdk.LookerSDK, roleID string) ([]string, error) {
 	lookerGroupIDs := make([]string, len(g))
 	for i, group := range g {
 		if group.Id == nil {
-			return nil, errors.Errorf("the user has a group with a missing id")
+			return nil, errors.New("the user has a group with a missing id")
 		}
 		lookerGroupIDs[i] = *group.Id
 	}

--- a/looker/resource_looker_role_groups_test.go
+++ b/looker/resource_looker_role_groups_test.go
@@ -1,6 +1,8 @@
 package looker
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -8,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	sdk "github.com/looker-open-source/sdk-codegen/go/sdk/v4"
-	"github.com/pkg/errors"
+
 	"github.com/resolutionlife/terraform-provider-looker/internal/conv"
 	"github.com/resolutionlife/terraform-provider-looker/internal/slice"
 )
@@ -161,7 +163,7 @@ func testAccRoleGroups(roleGroupResource string, groupResources []string) resour
 	return func(s *terraform.State) error {
 		roleGroupsRes, ok := s.RootModule().Resources[roleGroupResource]
 		if !ok {
-			return errors.Errorf("Not found: %s", roleGroupResource)
+			return fmt.Errorf("Not found: %s", roleGroupResource)
 		}
 		if roleGroupsRes.Primary.ID == "" {
 			return errors.New("role groups ID is not set")
@@ -171,7 +173,7 @@ func testAccRoleGroups(roleGroupResource string, groupResources []string) resour
 		for _, groupResource := range groupResources {
 			groupRes, ok := s.RootModule().Resources[groupResource]
 			if !ok {
-				return errors.Errorf("Not found: %s", groupResource)
+				return fmt.Errorf("Not found: %s", groupResource)
 			}
 			if groupRes.Primary.ID == "" {
 				return errors.New("group ID is not set")
@@ -190,7 +192,7 @@ func testAccRoleGroups(roleGroupResource string, groupResources []string) resour
 
 		roleGroups, err := client.RoleGroups(roleId[0], "", nil)
 		if err != nil {
-			return errors.Wrapf(err, "failed to retrieve role group with id: %v", roleGroupsRes.Primary.ID)
+			return fmt.Errorf("failed to retrieve role group with id %v: %w", roleGroupsRes.Primary.ID, err)
 		}
 
 		groupIds := []string{}
@@ -199,7 +201,7 @@ func testAccRoleGroups(roleGroupResource string, groupResources []string) resour
 		}
 
 		if !slice.UnorderedEqual(groupIds, expectedGroupIds) {
-			return errors.Errorf("groups in role do not match expected: %v actual: %v", expectedGroupIds, groupIds)
+			return fmt.Errorf("groups in role do not match expected: %v actual: %v", expectedGroupIds, groupIds)
 		}
 
 		return nil

--- a/looker/resource_looker_role_test.go
+++ b/looker/resource_looker_role_test.go
@@ -1,12 +1,14 @@
 package looker
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	sdk "github.com/looker-open-source/sdk-codegen/go/sdk/v4"
-	"github.com/pkg/errors"
+
 	"github.com/resolutionlife/terraform-provider-looker/internal/conv"
 	"github.com/resolutionlife/terraform-provider-looker/internal/slice"
 )
@@ -123,7 +125,7 @@ func testAccRole(roleResource string, expectedModelsSets, expectedPermSets []str
 	return func(s *terraform.State) error {
 		roleRes, ok := s.RootModule().Resources[roleResource]
 		if !ok {
-			return errors.Errorf("Not found: %s", roleResource)
+			return fmt.Errorf("Not found: %s", roleResource)
 		}
 		if roleRes.Primary.ID == "" {
 			return errors.New("role ID is not set")
@@ -133,15 +135,15 @@ func testAccRole(roleResource string, expectedModelsSets, expectedPermSets []str
 
 		role, err := client.Role(roleRes.Primary.ID, nil)
 		if err != nil {
-			return errors.Wrapf(err, "failed to retrieve role with id: %v", roleRes.Primary.ID)
+			return fmt.Errorf("failed to retrieve role with id %v: %w", roleRes.Primary.ID, err)
 		}
 
 		if !slice.UnorderedEqual(*role.PermissionSet.Permissions, expectedPermSets) {
-			return errors.Errorf("permissions in role do not match expected permissions: %v actual: %v", expectedPermSets, *role.PermissionSet.Permissions)
+			return fmt.Errorf("permissions in role do not match expected permissions: %v actual: %v", expectedPermSets, *role.PermissionSet.Permissions)
 		}
 
 		if !slice.UnorderedEqual(*role.ModelSet.Models, expectedModelsSets) {
-			return errors.Errorf("models in role do not match expected models: %v actual: %v", expectedModelsSets, *role.ModelSet.Models)
+			return fmt.Errorf("models in role do not match expected models: %v actual: %v", expectedModelsSets, *role.ModelSet.Models)
 		}
 
 		return nil

--- a/looker/resource_looker_user_attribute.go
+++ b/looker/resource_looker_user_attribute.go
@@ -2,6 +2,7 @@ package looker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -10,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	sdk "github.com/looker-open-source/sdk-codegen/go/sdk/v4"
-	"github.com/pkg/errors"
+
 	"github.com/resolutionlife/terraform-provider-looker/internal/conv"
 	"github.com/resolutionlife/terraform-provider-looker/internal/slice"
 )
@@ -207,7 +208,7 @@ func buildUserAttributeInput(d *schema.ResourceData) (*sdk.WriteUserAttribute, e
 
 	domainsWhitelistSlice, err := conv.SchemaSetToSliceString(domainsWhitelist)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to convert domain_whitelist to string slice")
+		return nil, fmt.Errorf("failed to convert domain_whitelist to string slice: %w", err)
 	}
 
 	domainWhitelistString := strings.Join(domainsWhitelistSlice, ",")

--- a/looker/resource_looker_user_attribute_group.go
+++ b/looker/resource_looker_user_attribute_group.go
@@ -2,10 +2,10 @@ package looker
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -221,7 +221,7 @@ func resourceUserAttributeGroupImport(ctx context.Context, d *schema.ResourceDat
 
 	userAttributes, err := api.UserAttribute(ids[0], "", nil)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to retrieve user_attribute with id %v", ids[0])
+		return nil, fmt.Errorf("failed to retrieve user_attribute with id %v: %w", ids[0], err)
 	}
 
 	if *userAttributes.ValueIsHidden {

--- a/looker/resource_looker_user_attribute_group_test.go
+++ b/looker/resource_looker_user_attribute_group_test.go
@@ -1,13 +1,14 @@
 package looker
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	sdk "github.com/looker-open-source/sdk-codegen/go/sdk/v4"
-	"github.com/pkg/errors"
 )
 
 func init() {
@@ -68,7 +69,7 @@ func testAccUserAttributeGroup(userAttrGroupResource, groupResource, expectedVal
 	return func(s *terraform.State) error {
 		userAttrGroupRes, ok := s.RootModule().Resources[userAttrGroupResource]
 		if !ok {
-			return errors.Errorf("Not found: %s", userAttrGroupResource)
+			return fmt.Errorf("Not found: %s", userAttrGroupResource)
 		}
 		if userAttrGroupRes.Primary.ID == "" {
 			return errors.New("user attribute group ID is not set")
@@ -76,7 +77,7 @@ func testAccUserAttributeGroup(userAttrGroupResource, groupResource, expectedVal
 
 		groupRes, ok := s.RootModule().Resources[groupResource]
 		if !ok {
-			return errors.Errorf("Not found: %s", groupRes)
+			return fmt.Errorf("Not found: %s", groupRes)
 		}
 		if groupRes.Primary.ID == "" {
 			return errors.New("group ID is not set")
@@ -92,13 +93,13 @@ func testAccUserAttributeGroup(userAttrGroupResource, groupResource, expectedVal
 		// id of user attribute is in form <user_attribute_id>_<group_id>_<...>
 		userAttrs, err := client.AllUserAttributeGroupValues(userAttrGroupIds[0], "", nil)
 		if err != nil {
-			return errors.Wrapf(err, "failed to retrieve user attribute group value with id: %v", userAttrGroupRes.Primary.ID)
+			return fmt.Errorf("failed to retrieve user attribute group value with id %v: %w", userAttrGroupRes.Primary.ID, err)
 		}
 
 		for _, userAttr := range userAttrs {
 			if *userAttr.GroupId == groupRes.Primary.ID {
 				if *userAttr.Value != expectedValue {
-					return errors.Errorf("value in user attribute group does not match expected: %v actual: %v", expectedValue, *userAttr.Value)
+					return fmt.Errorf("value in user attribute group does not match expected: %v actual: %v", expectedValue, *userAttr.Value)
 				}
 			}
 		}

--- a/looker/resource_looker_user_attribute_user.go
+++ b/looker/resource_looker_user_attribute_user.go
@@ -2,11 +2,10 @@ package looker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -147,7 +146,7 @@ func resourceUserAttributeUserImport(ctx context.Context, d *schema.ResourceData
 
 	userAttributes, err := api.UserAttribute(s[0], "", nil)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to retrieve user_attribute with id %v", s[0])
+		return nil, fmt.Errorf("failed to retrieve user_attribute with id %v: %w", s[0], err)
 	}
 
 	if *userAttributes.ValueIsHidden {

--- a/looker/resource_looker_user_attribute_user_test.go
+++ b/looker/resource_looker_user_attribute_user_test.go
@@ -1,13 +1,15 @@
 package looker
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/looker-open-source/sdk-codegen/go/rtl"
 	sdk "github.com/looker-open-source/sdk-codegen/go/sdk/v4"
-	"github.com/pkg/errors"
+
 	"github.com/resolutionlife/terraform-provider-looker/internal/conv"
 )
 
@@ -64,7 +66,7 @@ func testAccRoleUserAttributeUser(userResource, userAttrUserResource, expectedVa
 	return func(s *terraform.State) error {
 		userRes, ok := s.RootModule().Resources[userResource]
 		if !ok {
-			return errors.Errorf("Not found: %s", userResource)
+			return fmt.Errorf("Not found: %s", userResource)
 		}
 		if userRes.Primary.ID == "" {
 			return errors.New("user ID is not set")
@@ -72,7 +74,7 @@ func testAccRoleUserAttributeUser(userResource, userAttrUserResource, expectedVa
 
 		userAttrUserRes, ok := s.RootModule().Resources[userAttrUserResource]
 		if !ok {
-			return errors.Errorf("Not found: %s", userAttrUserResource)
+			return fmt.Errorf("Not found: %s", userAttrUserResource)
 		}
 		if userAttrUserRes.Primary.ID == "" {
 			return errors.New("user attribute ID is not set")
@@ -87,13 +89,13 @@ func testAccRoleUserAttributeUser(userResource, userAttrUserResource, expectedVa
 			Fields:           conv.P(""),
 		}, nil)
 		if err != nil {
-			return errors.Wrapf(err, "failed to retrieve user attribute values with id: %v", userRes.Primary.ID)
+			return fmt.Errorf("failed to retrieve user attribute values with id %v: %w", userRes.Primary.ID, err)
 		}
 
 		for _, userAttr := range userAttrs {
 			if *userAttr.UserAttributeId == userAttrUserRes.Primary.Attributes["user_attribute_id"] {
 				if *userAttr.Value != expectedValue {
-					return errors.Errorf("value in user attribute does not match expected: %v actual: %v", expectedValue, *userAttr.Value)
+					return fmt.Errorf("value in user attribute does not match expected: %v actual: %v", expectedValue, *userAttr.Value)
 				}
 			}
 		}

--- a/looker/resource_looker_user_roles.go
+++ b/looker/resource_looker_user_roles.go
@@ -2,6 +2,7 @@ package looker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	sdk "github.com/looker-open-source/sdk-codegen/go/sdk/v4"
-	"github.com/pkg/errors"
 
 	"github.com/resolutionlife/terraform-provider-looker/internal/conv"
 	"github.com/resolutionlife/terraform-provider-looker/internal/slice"
@@ -63,7 +63,7 @@ func resourceUserRolesCreate(ctx context.Context, d *schema.ResourceData, c inte
 
 	_, setErr := api.SetUserRoles(userID, append(diff, rscRoleIDs...), "", nil)
 	if err != nil {
-		return diag.FromErr(errors.Errorf("create set err: %s, userID: %s", setErr.Error(), userID))
+		return diag.FromErr(fmt.Errorf("create set err: %s, userID: %s", setErr.Error(), userID))
 	}
 
 	// the state has the role_ids provisioned in tf already, the id is a concat of the user_id and role_ids
@@ -222,7 +222,7 @@ func getRolesByUser(api *sdk.LookerSDK, userID string) ([]string, error) {
 	roleIDs := make([]string, len(ur))
 	for i, role := range ur {
 		if role.Id == nil {
-			return nil, errors.Errorf("the user has a role with a missing id")
+			return nil, errors.New("the user has a role with a missing id")
 		}
 		roleIDs[i] = *role.Id
 	}


### PR DESCRIPTION
This is a proposal to replace `github.com/pkg/errors` with standard library errors which can also be wrapped.