### PR TITLE
Fix: looker_role_groups - update the state when a role is already on a group

### DIFF
--- a/looker/resource_looker_role_groups.go
+++ b/looker/resource_looker_role_groups.go
@@ -67,9 +67,14 @@ func resourceRoleGroupsCreate(ctx context.Context, d *schema.ResourceData, c int
 		return diag.FromErr(gErr)
 	}
 
+	diff := slice.Diff(lookerGroupIDs, groupIDs)
+	if len(diff) <= 0 {
+		return resourceRoleGroupsRead(ctx, d, c)
+	}
+
 	// set all groups on the role
 	_, setErr := api.SetRoleGroups(roleID,
-		append(lookerGroupIDs, slice.Diff(lookerGroupIDs, groupIDs)...), // append diff to the list of groups already set in looker
+		append(lookerGroupIDs, diff...), // append diff to the list of groups already set in looker
 		nil,
 	)
 	if errors.Is(setErr, sdk.ErrNotFound) {


### PR DESCRIPTION
## Description: 

This PR returns early when what is in looker and what is being requested matches. The `read` is called which will update the state to be as expected. This is to prevent an unnecessary API call to the Looker API, as it can error when a resource already exists. 