### PR TITLE
Fix: Use updated fork and remove exceptions for io.EOF error message

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,4 +78,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/looker-open-source/sdk-codegen/go => github.com/resolutionlife/looker-sdk-codegen/go v0.0.0-20220930133853-1df0d14550ba
+replace github.com/looker-open-source/sdk-codegen/go => github.com/resolutionlife/looker-sdk-codegen/go v0.0.0-20230220144741-f9050910d834

--- a/go.sum
+++ b/go.sum
@@ -298,8 +298,8 @@ github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndr
 github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/resolutionlife/looker-sdk-codegen/go v0.0.0-20220930133853-1df0d14550ba h1:K6M9Wb/1lLdnVq4jQ4AagV5+LbgDf+FBISU7rmLU5Xo=
-github.com/resolutionlife/looker-sdk-codegen/go v0.0.0-20220930133853-1df0d14550ba/go.mod h1:umbd0XY6ocXX2F/TXVhiinxxoThUUokbrb2nLTDM/n4=
+github.com/resolutionlife/looker-sdk-codegen/go v0.0.0-20230220144741-f9050910d834 h1:3tHZioAM39ziamFRVKIzvkgawbClw/xw6s5i96s+Kcg=
+github.com/resolutionlife/looker-sdk-codegen/go v0.0.0-20230220144741-f9050910d834/go.mod h1:umbd0XY6ocXX2F/TXVhiinxxoThUUokbrb2nLTDM/n4=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=

--- a/looker/resource_looker_group_group.go
+++ b/looker/resource_looker_group_group.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -102,9 +101,7 @@ func resourceGroupGroupDelete(ctx context.Context, d *schema.ResourceData, c int
 		d.Get("group_id").(string),
 		nil,
 	)
-	// if the api call is successful the SDK returns an io.EOF error - this is not an error from looker and can be ignored
-	// TODO: amend this when the looker SDK has merged this PR https://github.com/looker-open-source/sdk-codegen/pull/1074
-	if !errors.Is(delErr, io.EOF) && !errors.Is(delErr, sdk.ErrNotFound) {
+	if !errors.Is(delErr, sdk.ErrNotFound) {
 		return diag.FromErr(delErr)
 	}
 

--- a/looker/resource_looker_group_user.go
+++ b/looker/resource_looker_group_user.go
@@ -2,9 +2,7 @@ package looker
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -104,9 +102,7 @@ func resourceGroupUserUpdate(ctx context.Context, d *schema.ResourceData, c inte
 	oldGr, newGr := d.GetChange("group_id")
 
 	// delete old user from old group
-	delErr := api.DeleteGroupUser(oldGr.(string), oldUsr.(string), nil)
-	// TODO: amend this when the looker SDK has merged this PR https://github.com/looker-open-source/sdk-codegen/pull/1074
-	if delErr != nil && !errors.Is(delErr, io.EOF) {
+	if delErr := api.DeleteGroupUser(oldGr.(string), oldUsr.(string), nil); delErr != nil {
 		return diag.FromErr(delErr)
 	}
 
@@ -128,14 +124,7 @@ func resourceGroupUserUpdate(ctx context.Context, d *schema.ResourceData, c inte
 func resourceGroupUserDelete(ctx context.Context, d *schema.ResourceData, c interface{}) diag.Diagnostics {
 	api := c.(*sdk.LookerSDK)
 
-	delErr := api.DeleteGroupUser(d.Get("group_id").(string), d.Get("user_id").(string), nil)
-	// the sdk attempts to decode the api response body into a nil struct - this is not an error from looker and can be ignored
-	// TODO: amend this when the looker SDK has merged this PR https://github.com/looker-open-source/sdk-codegen/pull/1074
-	if !errors.Is(delErr, io.EOF) {
-		return diag.FromErr(delErr)
-	}
-
-	return nil
+	return diag.FromErr(api.DeleteGroupUser(d.Get("group_id").(string), d.Get("user_id").(string), nil))
 }
 
 func resourceGroupUserImport(ctx context.Context, d *schema.ResourceData, c interface{}) ([]*schema.ResourceData, error) {

--- a/looker/resource_looker_user_attribute_groups.go
+++ b/looker/resource_looker_user_attribute_groups.go
@@ -3,7 +3,6 @@ package looker
 import (
 	"context"
 	"errors"
-	"io"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -164,8 +163,7 @@ func resourceUserAttributeGroupsDelete(ctx context.Context, d *schema.ResourceDa
 			d.Get(userAttrIdKey).(string),
 			nil,
 		)
-		// TODO: amend this when the looker SDK has merged this PR https://github.com/looker-open-source/sdk-codegen/pull/1074
-		if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, sdk.ErrNotFound) {
+		if err != nil && !errors.Is(err, sdk.ErrNotFound) {
 			return diag.FromErr(err)
 		}
 	}

--- a/looker/resource_looker_user_attribute_user.go
+++ b/looker/resource_looker_user_attribute_user.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -130,8 +129,7 @@ func resourceUserAttributeUserDelete(ctx context.Context, d *schema.ResourceData
 
 	// this delete removes the custom value and reverts back to the default value of the attribute, if set.
 	delErr := api.DeleteUserAttributeUserValue(userID, userAttrID, nil)
-	// TODO: amend this when the looker SDK has merged this PR https://github.com/looker-open-source/sdk-codegen/pull/1074
-	if !errors.Is(delErr, io.EOF) && !errors.Is(delErr, sdk.ErrNotFound) {
+	if !errors.Is(delErr, sdk.ErrNotFound) {
 		return diag.FromErr(delErr)
 	}
 


### PR DESCRIPTION
## Description

This PR updates dependencies to point to the most up-to-date `resolutionlife` branch on our fork `resolutionlife/looker-sdk-codegen`, which includes a fix to this bug: https://github.com/looker-open-source/sdk-codegen/pull/1074 (specifically[ this fix!](https://github.com/looker-open-source/sdk-codegen/pull/1193/files#diff-588a1a4bddb5631b55437eb311efa651bdf98f5878ef0d2fb14de73984167baaR121))

With this fix in, we no longer need to make exceptions when the API returns `io.EOF` error messages, so these are removed in this PR too. 